### PR TITLE
chore: raise dependency version floors for security hygiene

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,24 +10,24 @@
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-navigation-menu": "^1.2.14",
-        "@radix-ui/react-slot": "^1.1.1",
+        "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "next": "^16.0.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "tailwind-merge": "^2.6.0"
+        "next": "^16.1.7",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "tailwind-merge": "^2.6.1"
       },
       "devDependencies": {
-        "@types/node": "^22.10.2",
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
-        "autoprefixer": "^10.4.20",
-        "eslint": "^9.17.0",
-        "eslint-config-next": "^16.0.0",
-        "postcss": "^8.5.1",
-        "tailwindcss": "^3.4.17",
-        "typescript": "^5.7.2"
+        "@types/node": "^22.19.9",
+        "@types/react": "^19.2.13",
+        "@types/react-dom": "^19.2.3",
+        "autoprefixer": "^10.4.24",
+        "eslint": "^9.39.2",
+        "eslint-config-next": "^16.1.6",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^3.4.19",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -11,23 +11,23 @@
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-navigation-menu": "^1.2.14",
-    "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "next": "^16.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "tailwind-merge": "^2.6.0"
+    "next": "^16.1.7",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwind-merge": "^2.6.1"
   },
   "devDependencies": {
-    "@types/node": "^22.10.2",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "autoprefixer": "^10.4.20",
-    "eslint": "^9.17.0",
-    "eslint-config-next": "^16.0.0",
-    "postcss": "^8.5.1",
-    "tailwindcss": "^3.4.17",
-    "typescript": "^5.7.2"
+    "@types/node": "^22.19.9",
+    "@types/react": "^19.2.13",
+    "@types/react-dom": "^19.2.3",
+    "autoprefixer": "^10.4.24",
+    "eslint": "^9.39.2",
+    "eslint-config-next": "^16.1.6",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.19",
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce exposure to known vulnerabilities by aligning declared version ranges with patched package releases discovered in the environment.
- Make the lockfile and package metadata consistent after adjusting dependency baselines.

### Description
- Bumped dependency and devDependency ranges in `package.json` for several core packages including `next`, `react`, `react-dom`, `typescript`, `eslint`, `postcss`, `autoprefixer`, `tailwindcss`, `@radix-ui/react-slot`, `tailwind-merge`, and related `@types/*` packages.
- Regenerated `package-lock.json` (`npm install --package-lock-only --ignore-scripts --offline`) so the lock metadata matches the tightened ranges.
- No source code changes were required; only dependency metadata was updated (`package.json`, `package-lock.json`).

### Testing
- Ran `npm install --package-lock-only --ignore-scripts --offline` and it completed successfully with no vulnerabilities reported by the offline audit.
- Ran `npm run lint` and the linter completed successfully.
- Ran `npm audit --offline` which reported no vulnerabilities, and attempted an online `npm audit` returned `403 Forbidden` from the registry so online audit could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e161f1c1c0832aa68144c71657e289)